### PR TITLE
perf: speed up eww daemon reloading

### DIFF
--- a/config/eww/scripts/start.sh
+++ b/config/eww/scripts/start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Reload/Open eww
-eww kill
-eww daemon
+eww daemon --restart
 
 # Open widgets for monitor 1
 eww open yearbox


### PR DESCRIPTION
replacing 
```
eww kill
eww daemon
```
by
```
eww daemon --restart
```
in the eww startup script speeds up the reloading of eww (and reduces the risks caused by killing a process)