### PR TITLE
fix: correct typo in change_font_size command for minus shortcut so it would work properly :3

### DIFF
--- a/config/kitty/diinki_retro.conf
+++ b/config/kitty/diinki_retro.conf
@@ -17,7 +17,7 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
 
 # Background opacity, set to 0 if you want blur/transparency.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.


### PR DESCRIPTION
I installed your rice which is really nice btw but when i tried to change font in terminal using shortcuts i got error so i checked kitty config and find some typo :3 