### PR TITLE
Fix: correct Kitty keybinding for decreasing font size in alternate C…

### DIFF
--- a/alternate_version/kitty/diinki_retro_alt.conf
+++ b/alternate_version/kitty/diinki_retro_alt.conf
@@ -17,7 +17,8 @@ font_size 11
 
 # Just a keybind to change font size to your liking, it's CTRL + scroll wheel up or down.
 map ctrl+shift+plus change_font_size all +1.0
-map ctrl+shift+minus change font size all -1.0
+map ctrl+shift+minus change_font_size all -1.0
+
 
 # Background opacity, set to 0.7.
 # Blur works with hyprland, or sway-fx as a drop-in replacement for sway.


### PR DESCRIPTION
### Summary
This PR fixes a small typo in the Kitty configuration file for the alternate theme located at:

`alternate_version/kitty/diinki_retro_alt.conf`

### Problem
The keybinding for decreasing font size was incorrectly defined as:

    map ctrl+shift+minus change font size all -1.0

Which is invalid and causes Kitty to throw an error.

### Fix
Replaced it with the correct command:

    map ctrl+shift+minus change_font_size all -1.0

This allows the keybinding (Ctrl+Shift+-) to work as intended.

